### PR TITLE
Better instructions, with added mapping, to prevent 24hour issue

### DIFF
--- a/Instructions.md
+++ b/Instructions.md
@@ -62,6 +62,7 @@ Aggregates ECU consumption per deployment per day. Runs hourly, processing `metr
 ```json
 PUT _transform/billing_cluster_cost
 {
+  "description": "Aggregates daily total ECU usage per deployment from billing metrics, using ingested timestamps with a 1-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "metrics-ess_billing.billing-default"
@@ -130,6 +131,7 @@ Aggregates query time, indexing time, and storage size per deployment per day.
 ```json
 PUT _transform/cluster_deployment_contribution
 {
+  "description": "Aggregates daily total ECU usage per deployment from billing metrics, using ingested timestamps with a 1-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "monitoring-indices"
@@ -209,6 +211,7 @@ Aggregates query time, indexing time, and storage size per deployment, per tier,
 ```json
 PUT _transform/cluster_datastreams_contribution
 {
+  "description": "Aggregates daily query time, indexing time, and storage usage per data stream, cluster, and tier from monitoring indices, using ingested timestamps with a 24-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "monitoring-indices"
@@ -407,6 +410,7 @@ Then, recreate and start the transform with the correct pipelines.
 ```json
 PUT _transform/cluster_datastreams_contribution
 {
+  "description": "Aggregates daily query time, indexing time, and storage usage per data stream, cluster, and tier from monitoring indices, using ingested timestamps with a 24-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "monitoring-indices"

--- a/Instructions.md
+++ b/Instructions.md
@@ -125,6 +125,8 @@ POST _transform/billing_cluster_cost/_start
 ### Per Deployment
 Aggregates query time, indexing time, and storage size per deployment per day.
 
+**Note:** The integration looks at the `event.ingested` time, and therefore the transform mentioned in dependencies needs to have been started at least 24 hours before. If not, the process will fail when you try to set up the enrichment policy based on the output of the consumption transforms.
+
 ```json
 PUT _transform/cluster_deployment_contribution
 {
@@ -198,9 +200,11 @@ POST _transform/cluster_deployment_contribution/_start
 ```
 
 ### Per Data Stream
-Aggregates query time, indexing time, and storage size per deployment, per tier, per day. Runs hourly with a 24-hour delay to ensure completeness. This does mean that if you just setup the required integrations, you don't have 24h old data yet.
+Aggregates query time, indexing time, and storage size per deployment, per tier, per day. Runs hourly with a 24-hour delay to ensure completeness. This does mean that if you just setup the required integrations, you don't have 24h old data yet. 
 
-**Note:** Since the enrichment policies and pipelines are interdependent on the data stream transform, we first create the transform without the final pipeline.
+**Note 1:** The integration looks at the `event.ingested` time, and therefore the transform mentioned in dependencies needs to have been started at least 24 hours before. If not, the process will fail when you try to set up the enrichment policy based on the output of the consumption transforms.
+
+**Note 2:** Since the enrichment policies and pipelines are interdependent on the data stream transform, we first create the transform without the final pipeline.
 
 ```json
 PUT _transform/cluster_datastreams_contribution
@@ -301,6 +305,7 @@ POST /_enrich/policy/cluster_cost_enrich_policy/_execute
 ```
 
 ### Cluster Contribution
+
 Joins `sum_query_time`, `sum_indexing_time`, `sum_store_size`, `sum_data_set_store_size`, and `tier` from Elasticsearch integration with usage data.
 
 ```json

--- a/assets/mappings/cluster_deployment_contribution_mapping.json
+++ b/assets/mappings/cluster_deployment_contribution_mapping.json
@@ -1,0 +1,44 @@
+PUT cluster_deployment_contribution/_mapping
+{
+  "properties": {
+    "@timestamp": {
+      "type": "date"
+    },
+    "cluster_name": {
+      "type": "keyword"
+    },
+    "composite_tier_key": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "deployment_id": {
+      "type": "text",
+      "fields": {
+        "keyword": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
+    "sum_data_set_store_size": {
+      "type": "double"
+    },
+    "sum_indexing_time": {
+      "type": "double"
+    },
+    "sum_query_time": {
+      "type": "double"
+    },
+    "sum_store_size": {
+      "type": "double"
+    },
+    "tier": {
+      "type": "keyword"
+    }
+  }
+}

--- a/assets/transforms/billing_cluster_cost_transform.json
+++ b/assets/transforms/billing_cluster_cost_transform.json
@@ -1,5 +1,6 @@
 PUT _transform/billing_cluster_cost
 {
+  "description": "Aggregates daily total ECU usage per deployment from billing metrics, using ingested timestamps with a 1-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "metrics-ess_billing.billing-default"

--- a/assets/transforms/cluster_datastreams_contribution-placeholder_transform.json
+++ b/assets/transforms/cluster_datastreams_contribution-placeholder_transform.json
@@ -1,5 +1,6 @@
 PUT _transform/cluster_datastreams_contribution
 {
+  "description": "Aggregates daily query time, indexing time, and storage usage per data stream, cluster, and tier from monitoring indices, using ingested timestamps with a 24-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "monitoring-indices"

--- a/assets/transforms/cluster_datastreams_contribution_transform.json
+++ b/assets/transforms/cluster_datastreams_contribution_transform.json
@@ -1,5 +1,6 @@
 PUT _transform/cluster_datastreams_contribution
 {
+  "description": "Aggregates daily query time, indexing time, and storage usage per data stream, cluster, and tier from monitoring indices, using ingested timestamps with a 24-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "monitoring-indices"

--- a/assets/transforms/cluster_deployment_contribution_transform.json
+++ b/assets/transforms/cluster_deployment_contribution_transform.json
@@ -1,5 +1,6 @@
 PUT _transform/cluster_deployment_contribution
 {
+  "description": "Aggregates daily total ECU usage per deployment from billing metrics, using ingested timestamps with a 1-hour sync delay and running every 60 minutes.",
   "source": {
     "index": [
       "monitoring-indices"


### PR DESCRIPTION
Added mapping of deployment transform destination index to prevent 24h issue where the enrich cannot be created.
Also, added descriptions to transforms.