### PR TITLE
Remove index.hidden setting from chargeback_conf_lookup

### DIFF
--- a/integration/assets/0.2.8/setup_commands.json
+++ b/integration/assets/0.2.8/setup_commands.json
@@ -4,8 +4,7 @@
 PUT chargeback_conf_lookup
 {
   "settings": { 
-    "index.mode": "lookup", 
-    "index.hidden": true 
+    "index.mode": "lookup"
   },
   "mappings": {
     "_meta": {


### PR DESCRIPTION
The index.hidden setting is not needed for lookup indices and can cause issues with index visibility.